### PR TITLE
package.json: update gulp to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "restify": "7.2.1"
   },
   "devDependencies": {
-    "gulp": "3.9.1",
+    "gulp": "4.0.0",
     "gulp-replace": "1.0.0",
     "supertest": "3.1.0"
   }


### PR DESCRIPTION
Closes #13 

👋 @jirishus –– this PR updates `gulp` as a developer dependency from `3.9.1` to `4.0.0`.

Here are the results of running `npm audit`:

```js
npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities
 in 6629 scanned packages
```

I suggest considering integrating this project with something like [Greenkeeper](https://greenkeeper.io/) to automate dependency management, especially for those previous versions containing vulnerabilities.

Cheers! ✌️ 